### PR TITLE
Add netcdf4 to the conda environment creation step

### DIFF
--- a/mydoc/mydoc_cmor3_github.md
+++ b/mydoc/mydoc_cmor3_github.md
@@ -53,13 +53,13 @@ permalink: /mydoc_cmor3_github/
     For Python 2.7
    
     ```bash
-    conda create -q -n cmor_dev -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf numpy openssl lazy-object-proxy cdms2 python=2.7 $CONDA_COMPILERS testsrunner
+    conda create -q -n cmor_dev -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy cdms2 python=2.7 $CONDA_COMPILERS testsrunner
     ```
 
     For Python 3.7
    
     ```bash
-    conda create -q -n cmor_dev -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf numpy openssl lazy-object-proxy cdms2 python=3.7 $CONDA_COMPILERS testsrunner
+    conda create -q -n cmor_dev -c cdat/label/nightly -c conda-forge -c cdat libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy cdms2 python=3.7 $CONDA_COMPILERS testsrunner
     ```
   * Activate the conda environment
 


### PR DESCRIPTION
https://github.com/PCMDI/cmor/pull/493
NetCDF4 is now being used in CMOR so the source install instructions need to include it.