### PR TITLE
Update source install instructions

### DIFF
--- a/mydoc/mydoc_cmor3_github.md
+++ b/mydoc/mydoc_cmor3_github.md
@@ -6,12 +6,14 @@ sidebar: mydoc_sidebar
 permalink: /mydoc_cmor3_github/
 ---
 
-### Obtaining the sources
+### Obtaining the source code and CMIP6 tables
 
   * Clone the repo from gituhb
     ```bash
     git clone git://github.com/pcmdi/cmor
     cd cmor
+    git submodule init
+    git submodule update
     ```
 
 ### Anaconda System Requirements (if building using anaconda compilers)
@@ -53,13 +55,13 @@ permalink: /mydoc_cmor3_github/
     For Python 2.7
    
     ```bash
-    conda create -q -n cmor_dev -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy cdms2 python=2.7 $CONDA_COMPILERS testsrunner
+    conda create -q -n cmor_dev -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 libnetcdf=4.6.2 netcdf4 numpy openssl lazy-object-proxy cdms2 python=2.7 $CONDA_COMPILERS testsrunner
     ```
 
     For Python 3.7
    
     ```bash
-    conda create -q -n cmor_dev -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 libnetcdf netcdf4 numpy openssl lazy-object-proxy cdms2 python=3.7 $CONDA_COMPILERS testsrunner
+    conda create -q -n cmor_dev -c cdat/label/nightly -c conda-forge -c cdat six libuuid json-c udunits2 hdf5 libnetcdf=4.6.2 netcdf4 numpy openssl lazy-object-proxy cdms2 python=3.7 $CONDA_COMPILERS testsrunner
     ```
   * Activate the conda environment
 


### PR DESCRIPTION
Add cmip6-cmor-tables submodule update instructions, and pin libnetcdf to 4.6.2 in the source install instructions.