### PR TITLE
Change "Control Vocabulary" to "Controlled Vocabulary"

### DIFF
--- a/_data/sidebars/mydoc_sidebar.yml
+++ b/_data/sidebars/mydoc_sidebar.yml
@@ -72,7 +72,7 @@ entries:
       url: /mydoc_cmor3_c/
       output: web, pdf
 
-    - title: Control Vocabulary (CMIP6)
+    - title: Controlled Vocabulary (CMIP6)
       url: /mydoc_cmor3_CV/
       output: web, pdf
 

--- a/mydoc/examples/CMOR_input_example.json
+++ b/mydoc/examples/CMOR_input_example.json
@@ -56,7 +56,7 @@
  
     "#note":                  " **** The following are set correctly for CMIP6 and should not normally need editing",  
  
-    "_control_vocabulary_file": "CMIP6_CV.json",
+    "_controlled_vocabulary_file": "CMIP6_CV.json",
     "_AXIS_ENTRY_FILE":         "CMIP6_coordinate.json",
     "_FORMULA_VAR_FILE":        "CMIP6_formula_terms.json",
     "_cmip6_option":           "CMIP6",

--- a/mydoc/mydoc_cmip6_user_input.md
+++ b/mydoc/mydoc_cmip6_user_input.md
@@ -15,7 +15,7 @@ permalink: /mydoc_cmip6_user_input/
 
 [CMIP6_global_attributes_filenames_CVs.doc](https://docs.google.com/document/d/1h0r8RZr_f3-8egBMMh7aqLwy3snpD6_MrDz1q8n5XUk)
 
-* *_control_vocabulary_file*:"Specify Control Vocabulary file name -- default: CMIP6_CV.json"
+* *_controlled_vocabulary_file*:"Specify Controlled Vocabulary file name -- default: CMIP6_CV.json"
 
 * *_AXIS_ENTRY_FILE*:        "Specify Coordinate table file(axes) -- default: CMIP6_coordinate.json"
 
@@ -27,7 +27,7 @@ permalink: /mydoc_cmip6_user_input/
 
 * *output*:                  "Output Path where files are written -- must be created by the user."
 
-* *experiment_id*:           "Correspond to id found in \"_control_vocabulary_file\""
+* *experiment_id*:           "Correspond to id found in \"_controlled_vocabulary_file\""
 
 * *source_type*:             "type of model used",
 

--- a/mydoc/mydoc_cmip6_validator.md
+++ b/mydoc/mydoc_cmip6_validator.md
@@ -47,14 +47,14 @@ where:
 
 PrePARE will verify that all attributes in the input file are present and conform to CMIP6 for publication into ESGF.  We also recommand running the python program [cfchecker](https://pypi.python.org/pypi/cfchecker) created by the University of Reading in the UK to confirm that your file is CF-1 compliant.
 
-  * In order to validate all CMIP6 required attributes by PrePARE,  a [Control Vocabulary file](https://github.com/PCMDI/cmip6-cmor-tables/blob/master/Tables/CMIP6_CV.json) is read by the program where a JSON dictionnary called  ["required_global_attributes"](https://github.com/PCMDI/cmip6-cmor-tables/blob/master/Tables/CMIP6_CV.json#L3) point to a list of strings.  Each element of that list corresponds to a global attribute.  
+  * In order to validate all CMIP6 required attributes by PrePARE,  a [Controlled Vocabulary file](https://github.com/PCMDI/cmip6-cmor-tables/blob/master/Tables/CMIP6_CV.json) is read by the program where a JSON dictionnary called  ["required_global_attributes"](https://github.com/PCMDI/cmip6-cmor-tables/blob/master/Tables/CMIP6_CV.json#L3) point to a list of strings.  Each element of that list corresponds to a global attribute.  
   * PrePARE can also use regular expressions to validate the value of the some global attributes.  Here is an [example](https://github.com/PCMDI/cmip6-cmor-tables/blob/master/Tables/CMIP6_CV.json#L6343-L6344) used for variant_label.
 
   * Institutions and institution_ids need to be registered into a list.   PrePARE will only accept institutions which have been pre-registered for CMIP6 publication into ESGF.   Click [here](https://github.com/PCMDI/cmip6-cmor-tables/blob/master/Tables/CMIP6_CV.json#L65) for the list of institutions.  If you wish to register your institution write to the [cmor mailing list](mailto:cmor@listserv.llnl.gov).
 
   * Source and Source ID also need to be registered for CMIP6 publication.  Here is the [list](https://github.com/PCMDI/cmip6-cmor-tables/blob/master/Tables/CMIP6_CV.json#L93) of registered sources.
 
-  * Only experiments found in the Control Vocabulary files are accepted for CMIP6 publication. A list of [experiment_ids](https://github.com/PCMDI/cmip6-cmor-tables/blob/master/Tables/CMIP6_CV.json#L548) have been pre-defined including mandatory attributes.  A warning will be displayed if one experiment attribute is missing or is not properly set by your program.
+  * Only experiments found in the Controlled Vocabulary files are accepted for CMIP6 publication. A list of [experiment_ids](https://github.com/PCMDI/cmip6-cmor-tables/blob/master/Tables/CMIP6_CV.json#L548) have been pre-defined including mandatory attributes.  A warning will be displayed if one experiment attribute is missing or is not properly set by your program.
 
   * grid and nominal_resolution are mandatory global attributes in CMIP6.  PrePARE will make sure that these attributes are conformed to one of the following syntax:
 

--- a/mydoc/mydoc_cmor3_CV.md
+++ b/mydoc/mydoc_cmor3_CV.md
@@ -1,14 +1,14 @@
 ---
-title: Control Vocabulary (CMIP6)
-tags: [examples, Control Vocabulary, CMIP6]
+title: Controlled Vocabulary (CMIP6)
+tags: [examples, controlled_vocabulary, cmip6]
 keywords: example, C, Fortran, Python
 sidebar: mydoc_sidebar
 permalink: /mydoc_cmor3_CV/
 ---
 
-### CMIP6 Control vocabulary minimum requirements. 
+### CMIP6 Controlled vocabulary minimum requirements. 
 
-   * CMOR 3 required a new Control Vocabulary file which must contains 4 mandatory keys for CMIP6.
+   * CMOR 3 required a new Controlled Vocabulary file which must contains 4 mandatory keys for CMIP6.
        * institutions_ids:  A dictionary of of registered institution IDs with a description.
        * source_ids:  A dictionary of registered source IDS (model) with a ```specific``` description.
        * experiment_ids:  A dictionary of experiment_ids (CMIP6) pointing to a dictionary  of ```specific``` metadata.

--- a/mydoc/mydoc_cmor3_c.md
+++ b/mydoc/mydoc_cmor3_c.md
@@ -72,7 +72,7 @@ permalink: /mydoc_cmor3_c/
  
     "#note":                  " **** The following are set correctly for CMIP6 and should not normally need editing",  
  
-    "_control_vocabulary_file": "CMIP6_CV.json",
+    "_controlled_vocabulary_file": "CMIP6_CV.json",
     "_AXIS_ENTRY_FILE":         "CMIP6_coordinate.json",
     "_FORMULA_VAR_FILE":        "CMIP6_formula_terms.json",
     "_cmip6_option":           "CMIP6",

--- a/mydoc/mydoc_cmor3_c.md
+++ b/mydoc/mydoc_cmor3_c.md
@@ -1,6 +1,6 @@
 ---
 title: C example
-tags: [examples, C]
+tags: [examples, c]
 keywords: example, C
 sidebar: mydoc_sidebar
 permalink: /mydoc_cmor3_c/

--- a/mydoc/mydoc_cmor3_fortran.md
+++ b/mydoc/mydoc_cmor3_fortran.md
@@ -72,7 +72,7 @@ permalink: /mydoc_cmor3_fortran/
 
   "#note":                  " **** The following are set correctly for CMIP6 and should not normally need editing",  
 
-  "_control_vocabulary_file": "CMIP6_CV.json",
+  "_controlled_vocabulary_file": "CMIP6_CV.json",
   "_AXIS_ENTRY_FILE":         "CMIP6_coordinate.json",
   "_FORMULA_VAR_FILE":        "CMIP6_formula_terms.json",
   "_cmip6_option":           "CMIP6",

--- a/mydoc/mydoc_cmor3_fortran.md
+++ b/mydoc/mydoc_cmor3_fortran.md
@@ -1,6 +1,6 @@
 ---
 title: Fortran Example
-tags: [examples, FORTRAN]
+tags: [examples, fortran]
 keywords: example, Fortran
 sidebar: mydoc_sidebar
 permalink: /mydoc_cmor3_fortran/

--- a/mydoc/mydoc_cmor3_python.md
+++ b/mydoc/mydoc_cmor3_python.md
@@ -1,6 +1,6 @@
 ---
 title: Example Python
-tags: [examples,  Python]
+tags: [examples,  python]
 keywords: example, python
 sidebar: mydoc_sidebar
 permalink: /mydoc_cmor3_python/

--- a/tags/tag_c.html
+++ b/tags/tag_c.html
@@ -1,0 +1,8 @@
+---
+title: "C"
+tagName: c
+search: exclude
+permalink: /tag_c/
+sidebar: tags_sidebar
+---
+{% include taglogic.html %}

--- a/tags/tag_cmip6.html
+++ b/tags/tag_cmip6.html
@@ -1,0 +1,8 @@
+---
+title: "CMIP6"
+tagName: cmip6
+search: exclude
+permalink: /tag_cmip6/
+sidebar: tags_sidebar
+---
+{% include taglogic.html %}

--- a/tags/tag_controlled_vocabulary.html
+++ b/tags/tag_controlled_vocabulary.html
@@ -1,0 +1,8 @@
+---
+title: "Controlled Vocabulary"
+tagName: controlled_vocabulary
+search: exclude
+permalink: /tag_controlled_vocabulary/
+sidebar: tags_sidebar
+---
+{% include taglogic.html %}

--- a/tags/tag_fortran.html
+++ b/tags/tag_fortran.html
@@ -1,0 +1,8 @@
+---
+title: "Fortran"
+tagName: fortran
+search: exclude
+permalink: /tag_fortran/
+sidebar: tags_sidebar
+---
+{% include taglogic.html %}

--- a/tags/tag_python.html
+++ b/tags/tag_python.html
@@ -1,0 +1,8 @@
+---
+title: "Python"
+tagName: python
+search: exclude
+permalink: /tag_python/
+sidebar: tags_sidebar
+---
+{% include taglogic.html %}


### PR DESCRIPTION
@taylor13
Resolves #55 
It also adds tags that were missing for cmip6, controlled vocabulary, and the c, fortran, and python examples.