### PR TITLE
Remove "rc4" from nokogiri version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'jekyll'
-gem "nokogiri", ">= 1.11.0.rc4"
+gem "nokogiri", ">= 1.11.0"
 gem "json", ">= 2.3.0"
 gem "kramdown", ">= 2.3.0"
 gem "kramdown-parser-gfm"


### PR DESCRIPTION
The previous commit to update nokogiri was causing issues since the version couldn't be found in the gem sources.