### PR TITLE
Remove CDMS2 from Anaconda installation test, and update source install instructions

### DIFF
--- a/mydoc/mydoc_cmor3_conda.md
+++ b/mydoc/mydoc_cmor3_conda.md
@@ -61,9 +61,9 @@ permalink: /mydoc_cmor3_conda/
   * Run the CMIP6 CV Python tests
    
     ```bash
-    # Install cmor with cdms2 and testsrunner
+    # Install cmor with testsrunner
     # ------------------------------------------------
-    conda install -n CMOR -c conda-forge -c cdat/label/nightly -c cdat cdms2 testsrunner
+    conda install -n CMOR -c conda-forge -c cdat/label/nightly -c cdat testsrunner
 
     # Clone the CMOR repository to your working directory.
     # ------------------------------------------------

--- a/mydoc/mydoc_cmor3_github.md
+++ b/mydoc/mydoc_cmor3_github.md
@@ -57,6 +57,12 @@ permalink: /mydoc_cmor3_github/
     ```bash
     conda create -q -n cmor_dev -c conda-forge -c cdat/label/nightly -c cdat six libuuid json-c udunits2 hdf5 libnetcdf openblas netcdf4 numpy openssl lazy-object-proxy cdms2 python=3.9 $CONDA_COMPILERS testsrunner
     ```
+
+    For Python 3.11, omit the installation of CDMS2 as it doesn't support Python 3.11.
+   
+    ```bash
+    conda create -q -n cmor_dev -c conda-forge -c cdat/label/nightly -c cdat six libuuid json-c udunits2 hdf5 libnetcdf openblas netcdf4 numpy openssl lazy-object-proxy python=3.11 $CONDA_COMPILERS testsrunner
+    ```
   * Activate the conda environment
 
     ```bash


### PR DESCRIPTION
This is to help with the issue in #120 when installing and testing CMOR 3.7.1 with Python 3.11.  CDMS2 is not used in most of our tests so its absence wouldn't affect it much.

I have also added an additional part to the source install instructions asking users to omit CDMS2 from the conda environment when building CMOR with Python 3.11.